### PR TITLE
Merge FB_Axis2/FB_Axis3 into unified FB_Axis

### DIFF
--- a/BROTLib/BROTLib/BROTLib.plcproj
+++ b/BROTLib/BROTLib/BROTLib.plcproj
@@ -252,6 +252,10 @@
       <DefaultResolution>Tc2_MC2, * (Beckhoff Automation GmbH)</DefaultResolution>
       <Namespace>Tc2_MC2</Namespace>
     </PlaceholderReference>
+    <PlaceholderReference Include="Tc2_MC2_Drive">
+      <DefaultResolution>Tc2_MC2_Drive, * (Beckhoff Automation GmbH)</DefaultResolution>
+      <Namespace>Tc2_MC2_Drive</Namespace>
+    </PlaceholderReference>
     <PlaceholderReference Include="Tc2_NC">
       <DefaultResolution>Tc2_NC, * (Beckhoff Automation GmbH)</DefaultResolution>
       <Namespace>Tc2_NC</Namespace>

--- a/BROTLib/BROTLib/BROTLib.plcproj
+++ b/BROTLib/BROTLib/BROTLib.plcproj
@@ -128,7 +128,7 @@
     <Compile Include="POUs\FB_AstroClock.TcPOU">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="POUs\FB_Axis2.TcPOU">
+    <Compile Include="POUs\FB_Axis.TcPOU">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\FB_BaseAxis.TcPOU">

--- a/BROTLib/BROTLib/POUs/FB_Axis.TcPOU
+++ b/BROTLib/BROTLib/POUs/FB_Axis.TcPOU
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.15">
-  <POU Name="FB_Axis2" Id="{a3e55664-127b-4a99-a2ba-301ba26f68b3}" SpecialFunc="None">
-    <Declaration><![CDATA[FUNCTION_BLOCK FB_Axis2
+  <POU Name="FB_Axis" Id="{a3e55664-127b-4a99-a2ba-301ba26f68b3}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Axis
 VAR_INPUT
 	// enable the axis
 	Enable:		BOOL;
@@ -17,6 +17,12 @@ VAR_INPUT
 	Position: 	LREAL;
 	// maximum velocity
 	Velocity:	LREAL := 10.0;
+	// expected average tracking velocity
+	TrackVelocityRef: LREAL := 0.0;
+	// Tracking direction (-1,0,1)
+	TrackDirectionRef: INT := 0;
+	// PosDiff for isTracking (arcsec)
+	TrackEnvelope: LREAL := 5.0;
 	// Enable movement in positive direction (considering limit switch)
 	Enable_Positive:	BOOL := TRUE;
 	// Enable movement in negative direction (considering limit switch)
@@ -34,7 +40,7 @@ VAR_INPUT
 END_VAR
 VAR_OUTPUT
 	// Reset has been executed
-	ResetDone:	BOOL; 
+	ResetDone:	BOOL;
 	// the axis is in target position
 	MoveDone:	BOOL;
 	// the axis hass jogged
@@ -71,7 +77,7 @@ VAR_OUTPUT
 	ActualPosition: LREAL;
 	// axis is calibrated;
 	Calibrated:	BOOL := FALSE;
-	
+
 END_VAR
 VAR
 	Axis_Power:		MC_Power;
@@ -121,20 +127,14 @@ Axis_Reset(
 (* Tracking section ********************************************** *)
 
 IF Tracking THEN
-	PositionDifference := LIMIT(-0.002, Position - ActualPosition, 0.002);
-	(*
-	TrackPosition := Position;//ActualPosition + PositionDifference;
-	IF PositionDifference > 0.01 THEN
-		TrackVelocity := ABS(0.05);
+	PositionDifference := Position - ActualPosition;
+	TrackPosition := Position;
+	IF ABS(PositionDifference) > 0.01 THEN
+		TrackVelocity := 0.05;
 		TrackAcceleration := 0.05;
 	ELSE
-		TrackVelocity := LIMIT(0.0, Velocity, 0.05);
 		TrackAcceleration := 0.005;
 	END_IF
-	*)
-	TrackPosition := ActualPosition + PositionDifference;
-	TrackVelocity := 0.0; // LIMIT(-1.0, 2.0 * Velocity, 1.0);
-	TrackAcceleration := 0.0;
 ELSE
 	TrackPosition := ActualPosition;
 	TrackVelocity := 0.0;
@@ -142,17 +142,29 @@ ELSE
 END_IF
 
 
-IF NOT Tracking OR ABS(PositionDifference) < 1E-5 THEN // TrackVelocity = 0 AND TrackAcceleration = 0 THEN
-	Direction := 0;
-	TrackVelocity := 0.0;
-	TrackAcceleration := 0.0;	
+IF NOT Tracking OR ABS(PositionDifference) < 1E-5 THEN
+	Direction := TrackDirectionRef;
+	TrackAcceleration := 0.005;
 ELSIF PositionDifference < 0.0 THEN
 	Direction := -1;
+	IF TrackDirectionRef = -1 THEN
+		TrackVelocity := ABS(LIMIT(0.0, Velocity, 0.009));
+	ELSE
+		TrackVelocity := ABS(LIMIT(0.0, Velocity-TrackVelocityRef, 0.009));
+	END_IF
+
 ELSE
 	Direction := 1;
+	IF TrackDirectionRef = 1 THEN
+		TrackVelocity := ABS(LIMIT(0.0, Velocity, 0.009));
+	ELSE
+		TrackVelocity := ABS(LIMIT(0.0, Velocity-TrackVelocityRef, 0.009));
+	END_IF
 END_IF
 
-isTracking := Tracking AND ABS(Position - ActualPosition) < 5.0E-3;
+
+
+isTracking := Tracking AND ABS(Position - ActualPosition) < (TrackEnvelope/3600.0);
 IF Tracking AND Ready AND Calibrated AND NOT StopAxis THEN
 	Axis_SetpointEnable.Execute := TRUE;
 ELSIF NOT Axis_SetpointEnable.Busy AND Axis_SetpointEnable.Done THEN
@@ -162,21 +174,21 @@ END_IF
 Axis_SetpointEnable(Axis := AxisRef,
 	Position :=		TrackPosition,	// final destination
 	PositionType := POSITIONTYPE_ABSOLUTE);
-	
+
 MC_ExtSetPointGenFeed(
 	Position :=		TrackPosition,
-	Velocity :=		TrackVelocity,
+	Velocity :=		Direction*TrackVelocity,
 	Acceleration :=	TrackAcceleration,
-	Direction :=	Direction, 
+	Direction :=	Direction,
 	Axis :=			AxisRef);
 
 Axis_SetpointDisable(Axis := AxisRef,
 	Execute := NOT Tracking);
-	
+
 (* end of tracking section  ********************************************** *)
-	
+
 IF isModuloAxis THEN
-	Axis_Modulo( 
+	Axis_Modulo(
 		Axis := 		AxisRef,
 		Execute := 		MoveAxis AND Ready AND Calibrated,
 		Position := 	Position,
@@ -184,7 +196,7 @@ IF isModuloAxis THEN
 		Direction := 	MC_Shortest_Way,
 		Done => 		MoveDone);
 ELSE
-	Axis_Move( 
+	Axis_Move(
 		Axis := 		AxisRef,
 		Execute := 		MoveAxis AND Ready AND Calibrated,
 		Position := 	Position,
@@ -196,8 +208,9 @@ Axis_Jog(
 	JogForward := 	Jog_Forward AND Ready AND Enable_Positive,
 	JogBackwards := Jog_Backwards AND Ready AND Enable_Negative,
 	Mode := 		MC_JOGMODE_STANDARD_FAST,
-	Done => 		JogDone, 
+	Done => 		JogDone,
 	Axis := 		AxisRef);
+
 
 Axis_Home(
 	Axis := 			AxisRef,
@@ -205,8 +218,9 @@ Axis_Home(
 	Position := 		position, //DEFAULT_HOME_POSITION,
 	HomingMode :=		HomingMode,
 	bCalibrationCam := 	bCalibrationCam,
-	Done => 			HomeDone);	
-(*	
+	Done => 			HomeDone);
+
+(*
 IF (MoveDone OR HomeDone OR JogDone) AND NOT Axis_Status.StandStill THEN
 	StopAxis := TRUE;
 END_IF
@@ -220,22 +234,26 @@ IF JogDone THEN
 	Jog_Backwards := FALSE;
 END_IF
 
-IF HomeDone THEN
+IF Axis_Status.Status.Homed THEN
 	Calibrated := TRUE;
+	HomeDone := TRUE;
 	HomeAxis := FALSE;
+ELSE
+	Calibrated := FALSE;
+	HomeDone := FALSE;
 END_IF
 
 IF StopDone THEN
 	StopAxis := FALSE;
 END_IF
 
-StopAllowed :=	Axis_Status.StandStill OR  
+StopAllowed :=	Axis_Status.StandStill OR
 				Axis_Status.ContinuousMotion OR
 				Axis_Status.DiscreteMotion OR
 				Axis_Status.SynchronizedMotion OR
 				Axis_Status.Homing;
 
-Axis_Stop( 
+Axis_Stop(
 	Axis := 	AxisRef,
 	Execute := 	StopAxis AND StopAllowed,
 	Done => 	StopDone);
@@ -283,43 +301,47 @@ IF Axis_Stop.Error THEN
 	ErrorID := Axis_Stop.ErrorID;
 END_IF
 
+IF Axis_Status.Error THEN
+	ErrorID := Axis_Status.ErrorID;
+END_IF
 Busy := 	Axis_SetpointEnable.Busy OR
-			Axis_Reset.Busy OR 
+			Axis_Reset.Busy OR
 			Axis_Modulo.Busy OR
-			Axis_Move.Busy OR 
+			Axis_Move.Busy OR
 			Axis_Home.Busy OR
 			Axis_Jog.Busy;
 
-Error := 	Axis_Power.Error OR 
+Error := 	Axis_Power.Error OR
 			Axis_SetpointEnable.Error OR
-			Axis_Reset.Error OR 
+			Axis_Reset.Error OR
 			Axis_Modulo.Error OR
-			Axis_Move.Error OR 
+			Axis_Move.Error OR
 			Axis_Home.Error OR
-			Axis_Jog.Error OR 
-			Axis_Stop.Error;
+			Axis_Jog.Error OR
+			Axis_Stop.Error OR
+			Axis_Status.Error;
 
-Active := 	// Axis_Power.Active OR //alsways true if enabled 
+Active := 	// Axis_Power.Active OR //alsways true if enabled
 			Axis_Modulo.Active OR
-			Axis_Move.Active OR 
+			Axis_Move.Active OR
 			Axis_Home.Active OR
-			Axis_Jog.Active OR 
+			Axis_Jog.Active OR
 			Axis_Stop.Active;
 
 CommandAborted :=	Axis_Modulo.CommandAborted OR
-					Axis_Move.CommandAborted OR 
+					Axis_Move.CommandAborted OR
 					Axis_Home.CommandAborted OR
-					Axis_Jog.CommandAborted OR 
-					Axis_Stop.CommandAborted;	
-	
+					Axis_Jog.CommandAborted OR
+					Axis_Stop.CommandAborted;
+
 IF NOT Error THEN
 	ErrorID := 0;
 END_IF
-			
+
 InMotion := Axis_Status.ConstantVelocity OR
 			Axis_Status.DiscreteMotion OR
 			Axis_Status.ContinuousMotion OR
-			Axis_Status.SynchronizedMotion; 
+			Axis_Status.SynchronizedMotion;
 InRamp :=	Axis_Status.Accelerating OR
 			Axis_Status.Decelerating;
 Stopping := Axis_Status.Stopping;
@@ -327,144 +349,8 @@ StandStill := Axis_Status.StandStill;
 Homing :=	Axis_Status.Homing;
 // InPosition := AxisRef.NcToPlc.TargetPos;]]></ST>
     </Implementation>
-    <LineIds Name="FB_Axis2">
-      <LineId Id="292" Count="0" />
-      <LineId Id="200" Count="1" />
-      <LineId Id="1619" Count="0" />
-      <LineId Id="198" Count="0" />
-      <LineId Id="27" Count="0" />
-      <LineId Id="294" Count="0" />
-      <LineId Id="28" Count="4" />
-      <LineId Id="37" Count="1" />
-      <LineId Id="286" Count="0" />
-      <LineId Id="39" Count="1" />
-      <LineId Id="2023" Count="0" />
-      <LineId Id="1620" Count="0" />
-      <LineId Id="2028" Count="1" />
-      <LineId Id="2600" Count="0" />
-      <LineId Id="2903" Count="0" />
-      <LineId Id="2700" Count="6" />
-      <LineId Id="2699" Count="0" />
-      <LineId Id="2904" Count="0" />
-      <LineId Id="2372" Count="0" />
-      <LineId Id="2591" Count="0" />
-      <LineId Id="2589" Count="0" />
-      <LineId Id="2265" Count="1" />
-      <LineId Id="2376" Count="1" />
-      <LineId Id="2037" Count="0" />
-      <LineId Id="2024" Count="0" />
-      <LineId Id="1812" Count="0" />
-      <LineId Id="2590" Count="0" />
-      <LineId Id="2143" Count="0" />
-      <LineId Id="2805" Count="0" />
-      <LineId Id="2804" Count="0" />
-      <LineId Id="2142" Count="0" />
-      <LineId Id="1417" Count="0" />
-      <LineId Id="1419" Count="1" />
-      <LineId Id="1418" Count="0" />
-      <LineId Id="2256" Count="0" />
-      <LineId Id="2148" Count="2" />
-      <LineId Id="2152" Count="1" />
-      <LineId Id="2151" Count="0" />
-      <LineId Id="2007" Count="0" />
-      <LineId Id="2039" Count="1" />
-      <LineId Id="2042" Count="0" />
-      <LineId Id="2018" Count="0" />
-      <LineId Id="1287" Count="0" />
-      <LineId Id="1297" Count="3" />
-      <LineId Id="1296" Count="0" />
-      <LineId Id="1413" Count="0" />
-      <LineId Id="1288" Count="0" />
-      <LineId Id="1291" Count="0" />
-      <LineId Id="2026" Count="1" />
-      <LineId Id="1185" Count="0" />
-      <LineId Id="391" Count="0" />
-      <LineId Id="491" Count="3" />
-      <LineId Id="891" Count="0" />
-      <LineId Id="523" Count="0" />
-      <LineId Id="495" Count="0" />
-      <LineId Id="476" Count="0" />
-      <LineId Id="479" Count="3" />
-      <LineId Id="892" Count="0" />
-      <LineId Id="483" Count="0" />
-      <LineId Id="477" Count="0" />
-      <LineId Id="264" Count="0" />
-      <LineId Id="266" Count="3" />
-      <LineId Id="275" Count="0" />
-      <LineId Id="265" Count="0" />
-      <LineId Id="611" Count="0" />
-      <LineId Id="303" Count="2" />
-      <LineId Id="307" Count="0" />
-      <LineId Id="1909" Count="0" />
-      <LineId Id="1002" Count="0" />
-      <LineId Id="309" Count="0" />
-      <LineId Id="302" Count="0" />
-      <LineId Id="898" Count="2" />
-      <LineId Id="897" Count="0" />
-      <LineId Id="58" Count="2" />
-      <LineId Id="297" Count="2" />
-      <LineId Id="301" Count="0" />
-      <LineId Id="300" Count="0" />
-      <LineId Id="394" Count="2" />
-      <LineId Id="691" Count="0" />
-      <LineId Id="397" Count="0" />
-      <LineId Id="893" Count="3" />
-      <LineId Id="875" Count="5" />
-      <LineId Id="67" Count="1" />
-      <LineId Id="290" Count="0" />
-      <LineId Id="69" Count="0" />
-      <LineId Id="72" Count="2" />
-      <LineId Id="291" Count="0" />
-      <LineId Id="75" Count="0" />
-      <LineId Id="79" Count="0" />
-      <LineId Id="186" Count="0" />
-      <LineId Id="603" Count="1" />
-      <LineId Id="606" Count="1" />
-      <LineId Id="605" Count="0" />
-      <LineId Id="772" Count="0" />
-      <LineId Id="771" Count="0" />
-      <LineId Id="773" Count="1" />
-      <LineId Id="1513" Count="3" />
-      <LineId Id="776" Count="0" />
-      <LineId Id="775" Count="0" />
-      <LineId Id="777" Count="1" />
-      <LineId Id="881" Count="0" />
-      <LineId Id="794" Count="0" />
-      <LineId Id="882" Count="1" />
-      <LineId Id="788" Count="0" />
-      <LineId Id="787" Count="0" />
-      <LineId Id="789" Count="1" />
-      <LineId Id="917" Count="0" />
-      <LineId Id="913" Count="2" />
-      <LineId Id="783" Count="3" />
-      <LineId Id="779" Count="3" />
-      <LineId Id="903" Count="0" />
-      <LineId Id="905" Count="3" />
-      <LineId Id="911" Count="0" />
-      <LineId Id="909" Count="0" />
-      <LineId Id="791" Count="0" />
-      <LineId Id="608" Count="0" />
-      <LineId Id="1518" Count="0" />
-      <LineId Id="884" Count="2" />
-      <LineId Id="912" Count="0" />
-      <LineId Id="887" Count="1" />
-      <LineId Id="1177" Count="0" />
-      <LineId Id="1179" Count="1" />
-      <LineId Id="1182" Count="2" />
-      <LineId Id="1089" Count="0" />
-      <LineId Id="1186" Count="0" />
-      <LineId Id="1189" Count="3" />
-      <LineId Id="1178" Count="0" />
-      <LineId Id="1193" Count="0" />
-      <LineId Id="792" Count="0" />
-      <LineId Id="1091" Count="1" />
-      <LineId Id="1090" Count="0" />
-      <LineId Id="178" Count="0" />
-      <LineId Id="188" Count="2" />
-      <LineId Id="195" Count="1" />
-      <LineId Id="187" Count="0" />
-      <LineId Id="385" Count="1" />
-      <LineId Id="2482" Count="0" />
+    <LineIds Name="FB_Axis">
+      <LineId Id="1" Count="0" />
     </LineIds>
   </POU>
 </TcPlcObject>

--- a/BROTLib/BROTLib/POUs/FB_BaseAxis.TcPOU
+++ b/BROTLib/BROTLib/POUs/FB_BaseAxis.TcPOU
@@ -5,6 +5,7 @@
 VAR_INPUT
 	bEnable				: BOOL;		// enable the axis and its position control loop
 	bReset				: BOOL;		// reset the axis
+	bSoEReset			: BOOL;		// diagnostic reset
 	bHomeAxis			: BOOL;		// Home the axis
 	fPosition			: LREAL;	// position to move the axis to
 	fVelocity			: LREAL;	// set the Velocity of the axis
@@ -14,13 +15,15 @@ END_VAR
 VAR_OUTPUT
 	fActualPosition		: LREAL;	// actual_position of the axis
 	bCalibrated			: BOOL;		// true if absolute calibration
-	bError				: BOOL;		// true if error	
+	bError				: BOOL;		// true if error
 	nErrorID			: UDINT;	// error ID of the axis
 	bReady				: BOOL;		// drive is ready
 END_VAR
 VAR
-	fbComm				: I_Comm;	
+	fbComm				: I_Comm;
 	fbAxis				: FB_Axis;
+	fbSoEReset			: FB_SoEReset;
+	axisRef				: AXIS_REF;
 END_VAR
 ]]></Declaration>
     <Implementation>

--- a/BROTLib/BROTLib/POUs/FB_BaseAxis.TcPOU
+++ b/BROTLib/BROTLib/POUs/FB_BaseAxis.TcPOU
@@ -20,7 +20,7 @@ VAR_OUTPUT
 END_VAR
 VAR
 	fbComm				: I_Comm;	
-	fbAxis				: FB_Axis2;
+	fbAxis				: FB_Axis;
 END_VAR
 ]]></Declaration>
     <Implementation>


### PR DESCRIPTION
## Summary
- Merges `FB_Axis2` (BROTLib) and `FB_Axis3` (IAG50cm) into a single `FB_Axis`, per the plan in `FB_Axis.md`
- Adopts FB_Axis3's tracking/homing/error-handling logic as the superset: active velocity-aware tracking (instead of passive hold-position), continuous homing (Calibrated can drop back to FALSE), and `Axis_Status.Error` included in error aggregation
- New `TrackVelocityRef`/`TrackDirectionRef`/`TrackEnvelope` inputs default to values intended to preserve near-identical behavior for existing BROTLib callers
- Drops the unused `Axis_HomeLatch` declaration (`FB_LatchHome` doesn't exist in BROTLib) and a dead self-assignment (`TrackVelocityRef := TrackVelocityRef`)
- `FB_BaseAxis`'s `fbAxis` field retyped from `FB_Axis2` to `FB_Axis`

## Behavior change to flag explicitly
Tracking becomes **active** instead of passive by default: with a position error during tracking, BROTLib-derived axes (including MONETN/MONETS via MONETcommon) now receive a small feed velocity (~0.009) instead of 0. This is intentional per the unification plan, but is a real functional change to telescope hardware behavior, not just a refactor - please review with that in mind before this reaches a live mount.

## Test plan
- [x] Rebuilt cleanly in TwinCAT XAE (Release|TwinCAT RT (x64)): 0 errors, 0 warnings
- [ ] Verify tracking behavior on a simulated or real axis before deploying to hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)